### PR TITLE
Fix : Git clone url in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Get up and running in minutes using Docker.
 
 1.  **Clone the Repository**
     ```bash
-    git clone [https://github.com/Intervo/Intervo.git](https://github.com/Intervo/Intervo.git)
+    git clone https://github.com/Intervo/Intervo.git
     cd Intervo
     ```
 


### PR DESCRIPTION
Fix: Corrected Git clone command format in README.md

Changed from:

> git clone [url]   (url)

To:

> git clone url